### PR TITLE
process.cwd() replacement

### DIFF
--- a/lib/Iyzipay.js
+++ b/lib/Iyzipay.js
@@ -27,7 +27,7 @@ function Iyzipay(config) {
 
 Iyzipay.prototype._initResources = function () {
     var _self = this;
-    var modelsPath = process.cwd() + '/lib/resources';
+    var modelsPath = __dirname + '/resources';
     fs.readdirSync(modelsPath).forEach(function (fileName) {
         if (~fileName.indexOf('.js')) {
             var resource = require(modelsPath + '/' + fileName);


### PR DESCRIPTION
Fixes #3 
process.cwd() replaced for prevent file inclusion problems
