### PR TITLE
Array prototype fix for serialization of pki

### DIFF
--- a/lib/requests/BaseRequest.js
+++ b/lib/requests/BaseRequest.js
@@ -18,7 +18,7 @@ Request.prototype._generateRequestString = function (request) {
     var requestString = '[';
     for (var i in request) {
         var val = request[i];
-        if (typeof val !== 'undefined') {
+        if (typeof val !== 'undefined' && typeof val !== 'function') {
             // Eliminate number keys of array elements
             if (!isArray) {
                 requestString += i + '=';


### PR DESCRIPTION
Array prototype might be extended with functions globally. This will cause error "gecersiz imza".

this commit fixes #31 