### PR TITLE
Non-string value support added to formatPrice util.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,20 +41,17 @@ var utils = module.exports = {
         return process.hrtime()[0] + Math.random().toString(size).slice(2);
     },
     formatPrice: function (price) {
-        if (typeof price === "undefined") return price;
-        if (price.indexOf('.') === -1) return price + '.0';
-        var subStrIndex = 0;
-        var reversePrice = price.split("").reverse().join("");
-        for (var i = 0; i < reversePrice.length; i++) {
-            if (reversePrice[i] == 0) {
-                subStrIndex = i + 1;
-            } else if (reversePrice[i] == ".") {
-                reversePrice = "0" + reversePrice;
-                break;
-            } else {
-                break;
-            }
+        if (('number' !== typeof price && 'string' !== typeof price) || ! isFinite(price)) {
+            // throw new Error('Given price is not a valid number. (' + price + ')');
+            return price; // to pass previous written tests.
         }
-        return reversePrice.split("").reverse().join("").substring(0, reversePrice.length - subStrIndex);
+
+        var resultPrice = parseFloat(price).toString();
+
+        if (-1 === resultPrice.indexOf('.')) {
+            return resultPrice + '.0';
+        }
+
+        return resultPrice;
     }
 };

--- a/test/unit/UtilsTest.js
+++ b/test/unit/UtilsTest.js
@@ -110,4 +110,22 @@ describe('Iyzipay', function () {
         should.not.exist(price);
         done();
     });
+
+    it ('should return same price if given price is invalid', function (done) {
+        var price = utils.formatPrice(NaN);
+        price.should.be.NaN;
+        done();
+    });
+
+    it('should convert integer to string', function (done) {
+        var price = utils.formatPrice(23);
+        price.should.be.equal('23.0');
+        done();
+    });
+
+    it('should convert float to string', function (done) {
+        var price = utils.formatPrice(23.12);
+        price.should.be.equal('23.12');
+        done();
+    });
 });


### PR DESCRIPTION
Şu an formatPrice metoduna fiyat olarak bir Number yollanırsa bu sınıfta indexOf metodu olmadığı için hata oluşuyor. Metot daha önceki yazılmış testleri de kapsayacak şekilde yeniden yazıldı ve Number desteği eklendi.

Normalde bu metoda parse edilemeyecek bir data geldiği zaman hata fırlatacak şekilde yazılmıştı ancak backward compatibility için bunu devre dışı bıraktım. Şu an eğer verilen değer invalid ise tekrar aynı değeri geri dönüyor.