### PR TITLE
Remove duplicate `generateRequestString` function in utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,26 +17,6 @@ var utils = module.exports = {
         shaSum.update(apiKey + randomString + secretKey + body, 'utf8');
         return shaSum.digest('base64');
     },
-    generateRequestString: function (request) {
-        var isArray = Array.isArray(request);
-        var requestString = '[';
-        for (var i in request) {
-            var val = request[i];
-            // Eliminate number keys of array elements
-            if (!isArray) {
-                requestString += i + '=';
-            }
-            if (typeof val === 'object') {
-                requestString += utils.generateRequestString(val);
-            } else {
-                requestString += val;
-            }
-            requestString += isArray ? ', ' : ',';
-        }
-        requestString = requestString.slice(0, (isArray ? -2 : -1));
-        requestString += ']';
-        return requestString;
-    },
     generateRandomString: function (size) {
         return process.hrtime()[0] + Math.random().toString(size).slice(2);
     },

--- a/test/unit/BaseRequestTest.js
+++ b/test/unit/BaseRequestTest.js
@@ -1,0 +1,29 @@
+var assert = require('assert'),
+    should = require('should'),
+    BaseRequest = require('../../lib/requests/BaseRequest');
+
+describe('BaseRequest', function () {
+
+    before(function () {
+        request = new BaseRequest;
+    });
+
+    it('should generate request string for basic request', function (done) {
+        var requestString = request._generateRequestString({
+            name: "John",
+            surname: "Doe"
+        });
+        requestString.should.be.equal("[name=John,surname=Doe]");
+        done();
+    });
+
+    it('should generate request string for request that has array values', function (done) {
+        var requestString = request._generateRequestString({
+            name: "John",
+            surname: "Doe",
+            friends: [{name: "Johnny"}, {name: "Mike"}]
+        });
+        requestString.should.be.equal("[name=John,surname=Doe,friends=[[name=Johnny], [name=Mike]]]");
+        done();
+    });
+});

--- a/test/unit/UtilsTest.js
+++ b/test/unit/UtilsTest.js
@@ -43,25 +43,6 @@ describe('Iyzipay', function () {
         done();
     });
 
-    it('should generate request string for basic request', function (done) {
-        var requestString = utils.generateRequestString({
-            name: "John",
-            surname: "Doe"
-        });
-        requestString.should.be.equal("[name=John,surname=Doe]");
-        done();
-    });
-
-    it('should generate request string for request that has array values', function (done) {
-        var requestString = utils.generateRequestString({
-            name: "John",
-            surname: "Doe",
-            friends: [{name: "Johnny"}, {name: "Mike"}]
-        });
-        requestString.should.be.equal("[name=John,surname=Doe,friends=[[name=Johnny], [name=Mike]]]");
-        done();
-    });
-
     it('should generate random string', function (done) {
         var randomString = utils.generateRandomString(8);
         randomString.should.not.be.null;


### PR DESCRIPTION
`generateRequestString` is defined in both [Request](https://github.com/iyzico/iyzipay-node/blob/master/lib/requests/BaseRequest.js#L16) and [Utils](https://github.com/iyzico/iyzipay-node/blob/master/lib/utils.js#L20). However only the one that belongs to `Request` class is used through the api.

This PR removes the unused one which increases the readability and reduces LOC.