### PR TITLE
Add Missing "paymentItem.update" Method

### DIFF
--- a/lib/requests/UpdateSubMerchantPaymentItemRequest.js
+++ b/lib/requests/UpdateSubMerchantPaymentItemRequest.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var BaseRequest = require('./BaseRequest'),
+    util = require('util'),
+    PaymentItem = require('./model/PaymentItem');
+
+function UpdateSubMerchantPaymentItemRequest(request) {
+    BaseRequest.call(this, PaymentItem.body(request));
+}
+
+util.inherits(UpdateSubMerchantPaymentItemRequest, BaseRequest);
+
+module.exports = UpdateSubMerchantPaymentItemRequest;

--- a/lib/requests/model/PaymentItem.js
+++ b/lib/requests/model/PaymentItem.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var utils = require('../../utils');
+
+function PaymentItem() {}
+
+PaymentItem.body = function(data) {
+    return typeof data !== 'undefined'
+        ? {
+              subMerchantKey: data['subMerchantKey'],
+              paymentTransactionId: data['paymentTransactionId'],
+              subMerchantPrice: utils.formatPrice(data['subMerchantPrice'])          }
+        : undefined;
+};
+
+module.exports = PaymentItem;

--- a/lib/resources/PaymentItem.js
+++ b/lib/resources/PaymentItem.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var IyzipayResource = require('iyzipay/lib/IyzipayResource');
+
+function PaymentItem() {
+    this._config = arguments[0];
+    this._api = {
+        update: {
+            path: '/payment/item',
+            method: 'PUT',
+            requestModel: 'UpdateSubMerchantPaymentItemRequest'
+        }
+    };
+}
+
+PaymentItem.prototype = new IyzipayResource();
+
+module.exports = PaymentItem;

--- a/lib/resources/PaymentItem.js
+++ b/lib/resources/PaymentItem.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var IyzipayResource = require('iyzipay/lib/IyzipayResource');
+var IyzipayResource = require('../IyzipayResource');
 
 function PaymentItem() {
     this._config = arguments[0];

--- a/samples/IyzipaySamples.js
+++ b/samples/IyzipaySamples.js
@@ -795,6 +795,22 @@ describe('Iyzipay API Test', function () {
         });
     });
 
+    describe('Payment Item', function() {
+        it('should update subMerchantPrice on a single payment transaction', function(done) {
+            iyzipay.paymentItem.update(
+                {
+                    paymentTransactionId: '12345678',
+                    subMerchantKey: 'sub merchant key',
+                    subMerchantPrice: '18.22'
+                },
+                function(err, result) {
+                    console.log(err, result);
+                    done();
+                }
+            );
+        });
+    });
+
     describe('Pecco', function () {
 
         it('should initialize pecco', function (done) {


### PR DESCRIPTION
We noticed that the Update method for payment transactions is missing. But this method exists in php and c# repositories.
Added Files
```
lib/requests/UpdateSubMerchantPaymentItemRequest.js
lib/requests/model/PaymentItem.js 
lib/resources/PaymentItem.js
```

Edited Files
```
samples/IyzipaySamples.js 
```

We realy needed this update. So our application will be using my fork until this pull request is merged or until an alternative is available.

