### PR TITLE
http client replacement and general dependency upgrade

### DIFF
--- a/lib/IyzipayResource.js
+++ b/lib/IyzipayResource.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var request = require('request'),
-    crypto = require('crypto'),
+var axios = require('axios'),
     utils = require('./utils');
 
 function IyzipayResource() {
@@ -105,12 +104,12 @@ IyzipayResource.prototype._request = function (method, cb) {
         method: this._getMethod(method),
         url: this._getUrl(method),
         headers: this._getHttpHeaders(method),
-        qs: this._getQueryString(method),
-        json: this._getBody(method)
+        params: this._getQueryString(method),
+        data: this._getBody(method)
     };
-    request(options, function (error, response, body) {
-        cb(error, response, body);
-    });
+    axios(options)
+        .then( response => cb(null, response, response.data))
+        .catch(e => cb(e, e.response, e.response && e.response.data))
 };
 
 IyzipayResource.prototype.create = function (params, cb) {

--- a/package.json
+++ b/package.json
@@ -33,15 +33,15 @@
   },
   "homepage": "https://github.com/iyzico/iyzipay-node",
   "dependencies": {
-    "request": "2.69.0"
+    "axios": "^0.19.2"
   },
   "devDependencies": {
-    "async": "^1.5.2",
-    "coveralls": "^2.11.6",
+    "async": "^3.2.0",
+    "coveralls": "^3.0.11",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
+    "mocha": "^7.1.1",
     "mocha-lcov-reporter": "^1.0.0",
-    "should": "^8.2.1",
-    "supertest": "^1.1.0"
+    "should": "^13.2.3",
+    "supertest": "^4.0.2"
   }
 }


### PR DESCRIPTION
The branch contains version upgrades for the following packages and also HTTP client has been replaced with `axios`  because of the package called`request` is deprecated.

```
should
mocha
async
coveralls
```