### PR TITLE
Pin postman-request to 2.88.1-postman.48 to avoid resolving to vulnerable beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/iyzico/iyzipay-node",
   "dependencies": {
-    "postman-request": "^2.88.1-postman.40"
+    "postman-request": "2.88.1-postman.48"
   },
   "devDependencies": {
     "mocha": "^12.0.0-beta-10",


### PR DESCRIPTION
## Sorun

`iyzipay`'ın `postman-request` bağımlılığı eski bir beta sürüme (`2.88.1-postman.8-beta.1`) düşüyor. Bu beta scope'suz `form-data` ve `tough-cookie` kullanıyor; `npm audit` critical ve moderate açıklar raporluyor.

## Çözüm

`postman-request`'i stable `2.88.1-postman.48`'e pin'lemek vuln'ları temizliyor.

```diff
-    "postman-request": "^2.88.1-postman.40"
+    "postman-request": "2.88.1-postman.48"
```

Bu sorun bizim CI'ımızdaki `npm audit` kontrolünü de bloke ediyor.

Closes #141.

---

## Issue

`iyzipay`'s `postman-request` dependency resolves to an old beta (`2.88.1-postman.8-beta.1`) that uses unscoped `form-data` and `tough-cookie`, producing critical and moderate `npm audit` findings.

## Fix

Pinning `postman-request` to stable `2.88.1-postman.48` clears the advisories.

```diff
-    "postman-request": "^2.88.1-postman.40"
+    "postman-request": "2.88.1-postman.48"
```

This also blocks our CI's `npm audit` check.

Closes #141.